### PR TITLE
Fix build against current Dumper-7: EFunctionFlags is a scoped enum now

### DIFF
--- a/Grounded2Minimal/HookManager.hpp
+++ b/Grounded2Minimal/HookManager.hpp
@@ -189,11 +189,11 @@ namespace HookManager {
 
         static inline bool IsNative(const SDK::UFunction* lpcTargetFunc) {
             constexpr uint32_t FUNC_Native = 0x00000400;
-            return lpcTargetFunc && (lpcTargetFunc->FunctionFlags & FUNC_Native);
+            return lpcTargetFunc && (static_cast<uint32_t>(lpcTargetFunc->FunctionFlags) & FUNC_Native);
         };
 
         static inline uint32_t ReadFlags(const SDK::UFunction* lpcTargetFunc) {
-            return lpcTargetFunc ? lpcTargetFunc->FunctionFlags : 0;
+            return lpcTargetFunc ? static_cast<uint32_t>(lpcTargetFunc->FunctionFlags) : 0;
         }
 
         static bool SwapExecFunctionPtr(


### PR DESCRIPTION
## Summary
- `HookManager::IsNative` and `HookManager::ReadFlags` do `lpcTargetFunc->FunctionFlags & FUNC_Native` / implicit conversion to `uint32_t`, assuming `SDK::EFunctionFlags` implicitly converts to an integer.
- A fresh SDK dump from the current Dumper-7 generates `enum class EFunctionFlags : uint32` (scoped enum) with only `EFunctionFlags & EFunctionFlags -> bool` via `UE_ENUM_OPERATORS`, no overload against a raw `uint32_t`. This fails to compile with C2678/C2440.
- This blocks the documented recovery path in the README ("Building" section) for the game-update crashes reported in #22, #25, #27, #30, #31, #33, #37 -- regenerating the SDK dump and rebuilding is exactly what those issues need, but it doesn't compile without this fix.

## Fix
Explicit `static_cast<uint32_t>(...)` at the two call sites in `HookManager.hpp`. No behavior change for SDKs where the enum was already integer-convertible.

## Test plan
- [x] Rebuilt against a fresh Dumper-7 dump for `Grounded2Steam-Win64-Shipping` (Augusta-CL-3058459 / 0.5.0.3), Release-Steam|x64.
- [x] Injected into a live game session already loaded into a save -- no crash, GUI initializes, `[HostCheck] Player: ... (Authority: Yes)`, hooks install successfully.
- [x] Repeated from a clean state: killed the game, relaunched, reloaded the save, injected into the fresh process -- same result, no crash.

Related: #37