### PR TITLE
Add new cheats, game version compatibility check, updated for 0.5.0.3

### DIFF
--- a/Grounded2Minimal/CheatManager.cpp
+++ b/Grounded2Minimal/CheatManager.cpp
@@ -366,6 +366,33 @@ namespace CheatManager {
             );
         }
 
+        // Breath Regen
+        float CurrentBreathAdjustRate(
+            EStaticCheatOp eOperation,
+            int32_t iTargetPlayerId,
+            float fNewBreathAdjustRate
+        ) {
+            auto getter = [](SDK::ASurvivalPlayerCharacter* pc) -> float {
+                g_GameOptions.GameStatics.BreathAdjustRate.store(
+                    pc->SurvivalComponent->BreathSettings.AdjustmentPerSecond, 
+                    std::memory_order_release
+                );
+                return pc->SurvivalComponent->BreathSettings.AdjustmentPerSecond;
+            };
+            auto setter = [](SDK::ASurvivalPlayerCharacter* pc, float value) {
+                pc->SurvivalComponent->BreathSettings.AdjustmentPerSecond = value;
+                g_GameOptions.GameStatics.BreathAdjustRate.store(value, std::memory_order_release);
+            };
+            return HandleFloatCharCheat(
+                eOperation,
+                iTargetPlayerId,
+                fNewBreathAdjustRate,
+                "CurrentBreathAdjustRate",
+                getter,
+                setter
+            );
+        }
+
         void ToggleHandyGnat(
             bool bEnable
         ) {
@@ -450,6 +477,8 @@ namespace CheatManager {
                 return;
             }
             lpSettings->PlayerDamageMultiplier = fNewMultiplier;
+
+            g_GameOptions.GameStatics.PlayerDamageMultiplier.store(fNewMultiplier, std::memory_order_release);
         }
 
         void SetGameType(
@@ -1097,6 +1126,16 @@ namespace CheatManager {
                 break;
             }
 
+            case CheatManagerFunctionId::AddBuggyUpgradePoints: {
+                if (nullptr == alpqwParams) {
+                    LogError("CheatManager", "Params are NULL for AddBuggyUpgradePoints");
+                    return;
+                }
+                int32_t iAmount = static_cast<int32_t>(alpqwParams[0]);
+                SurvivalCheatManager->AddBuggyUpgradePoints(iAmount);
+                break;
+            }
+
             case CheatManagerFunctionId::AddRawScience: {
                 if (nullptr == alpqwParams) {
                     LogError("CheatManager", "Params are NULL for AddRawScience");
@@ -1106,6 +1145,27 @@ namespace CheatManager {
                 int32_t iAmount = static_cast<int32_t>(alpqwParams[0]);
                 SurvivalCheatManager->AddScience(iAmount);
 
+                break;
+            }
+
+            case CheatManagerFunctionId::Revive: {
+                SurvivalCheatManager->Revive();
+                break;
+            }
+
+            case CheatManagerFunctionId::AdvanceTimeByHours: {
+                if (nullptr == alpqwParams) {
+                    LogError("CheatManager", "Params are NULL for AdvanceTimeByHours");
+                    return;
+                }
+                float fHours = *reinterpret_cast<const float*>(&alpqwParams[0]);
+                SurvivalCheatManager->AdvanceTimeByHours(fHours);
+                break;
+            }
+
+            case CheatManagerFunctionId::ToggleInfiniteDamage: {
+                g_GameOptions.InfiniteDamage.fetch_xor(1, std::memory_order_acq_rel);
+                SurvivalCheatManager->InfiniteDamage();
                 break;
             }
 

--- a/Grounded2Minimal/CheatManager.hpp
+++ b/Grounded2Minimal/CheatManager.hpp
@@ -23,6 +23,7 @@ namespace CheatManager {
         float DodgeDistance(EStaticCheatOp eOperation, int32_t iTargetPlayerId, float fNewSetValue);
         float CurrentFoodLevel(EStaticCheatOp eOperation, int32_t iTargetPlayerId, float fNewSetValue);
         float CurrentWaterLevel(EStaticCheatOp eOperation, int32_t iTargetPlayerId, float fNewSetValue);
+        float CurrentBreathAdjustRate(EStaticCheatOp eOperation, int32_t iTargetPlayerId, float fNewSetValue);
         float StaminaRegenRate(EStaticCheatOp eOperation, int32_t iTargetPlayerId, float fNewRegenRate);
         float StaminaRegenDelay(EStaticCheatOp eOperation, int32_t iTargetPlayerId, float fNewRegenDelay);
         
@@ -102,8 +103,12 @@ namespace CheatManager {
         None = 0,
         AddWhiteMolars,
         AddGoldMolars,
+        AddBuggyUpgradePoints,
         AddRawScience,
+        AdvanceTimeByHours,
+        Revive,
         ToggleHud,
+        ToggleInfiniteDamage,
         UnlockAllRecipes,
         UnlockAllLandmarks,
         UnlockMutations,

--- a/Grounded2Minimal/CoreUtils.cpp
+++ b/Grounded2Minimal/CoreUtils.cpp
@@ -267,4 +267,38 @@ namespace CoreUtils {
         }
         return reinterpret_cast<uintptr_t>(hModule);
     }
+
+    DWORD32 GetTextRVA(
+        LPCBYTE lpBaseAddress
+    ) {
+        PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER) lpBaseAddress;
+        if (IMAGE_DOS_SIGNATURE != pDosHeader->e_magic) {
+            LogError(
+                "GetTextRVA",
+                "[-] Invalid DOS header signature: " + CoreUtils::HexConvert(pDosHeader->e_magic) + "\n"
+            );
+            return 0;
+        }
+
+        PIMAGE_NT_HEADERS pNtHeaders = (PIMAGE_NT_HEADERS) (lpBaseAddress + pDosHeader->e_lfanew);
+        if (IMAGE_NT_SIGNATURE != pNtHeaders->Signature) {
+            LogError(
+                "GetTextRVA",
+                "[-] Invalid NT header signature: " + CoreUtils::HexConvert(pNtHeaders->Signature) + "\n"
+            );
+            return 0;
+        }
+
+        PIMAGE_SECTION_HEADER pSectionHeaders = \
+            (PIMAGE_SECTION_HEADER) (lpBaseAddress + pDosHeader->e_lfanew + sizeof(IMAGE_NT_HEADERS));
+        for (WORD i = 0; i < pNtHeaders->FileHeader.NumberOfSections; i++) {
+            if (0 == strcmp(
+                (LPCSTR) pSectionHeaders[i].Name,
+                ".text"
+            )) {
+                return pSectionHeaders[i].VirtualAddress - pSectionHeaders[i].PointerToRawData;
+            }
+        }
+        return 0;
+    }
 }

--- a/Grounded2Minimal/CoreUtils.hpp
+++ b/Grounded2Minimal/CoreUtils.hpp
@@ -56,6 +56,10 @@ namespace CoreUtils {
     uintptr_t GetModuleBaseAddressW(
         const wchar_t* wszModuleName
     );
+
+    DWORD32 GetTextRVA(
+        LPCBYTE lpBaseAddress
+    );
 } // namespace CoreUtils
 
 #endif // _GROUNDED_MINIMAL_CORE_UTILS_HPP

--- a/Grounded2Minimal/Grounded2Minimal.hpp
+++ b/Grounded2Minimal/Grounded2Minimal.hpp
@@ -39,6 +39,7 @@ struct GameOptions {
     std::atomic<ubool> BuildAnywhere{ false };
     std::atomic<ubool> GodMode{ false };
     std::atomic<ubool> InfiniteStamina{ false };
+    std::atomic<ubool> InfiniteDamage{ false };
     struct _GameStatics {
         std::atomic<ubool> HandyGnatForceEnable{ false };
         std::atomic<ubool> AutoCompleteBuildings{ false };
@@ -46,6 +47,7 @@ struct GameOptions {
         std::atomic<ubool> FreeCrafting{ false };
         std::atomic<ubool> InvinciblePets{ false };
         std::atomic<float> PlayerDamageMultiplier{ 1.0f };
+        std::atomic<float> BreathAdjustRate{ 1.0f };
     } GameStatics;
     std::atomic<SDK::ABuilding *> CurrentlyAdjustedBuilding = nullptr;
 };

--- a/Grounded2Minimal/Grounded2Minimal.rc
+++ b/Grounded2Minimal/Grounded2Minimal.rc
@@ -50,8 +50,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,2,8,1
-PRODUCTVERSION 2,2,8,1
+FILEVERSION 2,2,8,2
+PRODUCTVERSION 2,2,8,2
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "x0reaxeax"
             VALUE "FileDescription", "Grounded2Minimal Tool"
-            VALUE "FileVersion", "2.2.8.1"
+            VALUE "FileVersion", "2.2.8.2"
             VALUE "InternalName", "Grounded2Minimal.dll"
             VALUE "LegalCopyright", "Copyright (C) 2026 x0reaxeax"
             VALUE "OriginalFilename", "Grounded2Minimal.dll"
             VALUE "ProductName", "Grounded2Minimal"
-            VALUE "ProductVersion", "2.2.8.1"
+            VALUE "ProductVersion", "2.2.8.2"
         END
     END
     BLOCK "VarFileInfo"

--- a/Grounded2Minimal/Grounded2Minimal.rc
+++ b/Grounded2Minimal/Grounded2Minimal.rc
@@ -50,8 +50,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,2,8,0
-PRODUCTVERSION 2,2,8,0
+FILEVERSION 2,2,8,1
+PRODUCTVERSION 2,2,8,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "x0reaxeax"
             VALUE "FileDescription", "Grounded2Minimal Tool"
-            VALUE "FileVersion", "2.2.8.0"
+            VALUE "FileVersion", "2.2.8.1"
             VALUE "InternalName", "Grounded2Minimal.dll"
             VALUE "LegalCopyright", "Copyright (C) 2026 x0reaxeax"
             VALUE "OriginalFilename", "Grounded2Minimal.dll"
             VALUE "ProductName", "Grounded2Minimal"
-            VALUE "ProductVersion", "2.2.8.0"
+            VALUE "ProductVersion", "2.2.8.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/Grounded2Minimal/Interpreter.cpp
+++ b/Grounded2Minimal/Interpreter.cpp
@@ -887,6 +887,63 @@ namespace Interpreter {
         }
     }
 
+    static void HandleBreathAdjustRate(
+        CheatManager::StaticCheats::EStaticCheatOp eOperation
+    ) {
+        using StaticOp = CheatManager::StaticCheats::EStaticCheatOp;
+        const bool bIsSet = (eOperation == StaticOp::Set);
+        std::string szOperationStr = bIsSet ? "set" : "get";
+        float fBreathAdjustRate = 0.0f;
+        if (bIsSet) {
+            fBreathAdjustRate = ReadFloatInput(
+                "[BreathAdjustRate] Enter new breath adjust rate: ",
+                -1.0f
+            );
+            if (fBreathAdjustRate < 0.0f) {
+                LogError(
+                    "BreathAdjustRate",
+                    "Invalid breath adjust rate, must be non-negative"
+                );
+                return;
+            }
+            LogMessage(
+                "BreathAdjustRate",
+                "Setting breath adjust rate to " + std::to_string(fBreathAdjustRate)
+            );
+        }
+        int32_t iTargetPlayerId = ReadIntegerInput(
+            "[BreathAdjustRate] Enter target player ID (empty for local): ",
+            UnrealUtils::GetLocalPlayerId(true)
+        );
+        float fResult = CheatManager::StaticCheats::CurrentBreathAdjustRate(
+            eOperation,
+            iTargetPlayerId,
+            fBreathAdjustRate   // ignored for Get
+        );
+
+        if (fResult < 0.0f) {
+            LogError(
+                "BreathAdjustRate",
+                "Failed to " + szOperationStr + " breath adjust rate"
+            );
+            return;
+        }
+        if (bIsSet) {
+            LogMessage(
+                "BreathAdjustRate",
+                "Breath adjust rate successfully set to " + std::to_string(fResult) +
+                " for player ID " + std::to_string(iTargetPlayerId)
+            );
+        } else {
+            LogMessage(
+                "BreathAdjustRate",
+                "Current breath adjust rate for player ID " +
+                std::to_string(iTargetPlayerId) + ": " +
+                std::to_string(fResult)
+            );
+        }
+    }
+
     static void HandleSetOmniToolLevel(void) {
         int32_t iOmniToolLevel = ReadIntegerInput(
             "[OmniToolLevel] Enter new OmniTool level: ",
@@ -1157,7 +1214,6 @@ namespace Interpreter {
         }
 
         CheatManager::StaticCheats::SetPlayerDamageMultiplier(fDamageMultiplier);
-        g_GameOptions.GameStatics.PlayerDamageMultiplier.store(fDamageMultiplier, std::memory_order_release);
 
         LogMessage(
             "SetPlayerDamageMultiplier",
@@ -1198,6 +1254,133 @@ namespace Interpreter {
             lpParams
         );
     }
+
+    static void HandleToggleInfiniteDamage(void) {
+        CheatManager::CheatManagerParams* lpParams = new CheatManager::CheatManagerParams{
+            .FunctionId = CheatManager::CheatManagerFunctionId::ToggleInfiniteDamage,
+            .FunctionParams = {
+                reinterpret_cast<uint64_t>(
+                    UnrealUtils::GetSurvivalPlayerCharacterById()
+                ),
+                0, 0, 0
+            }
+        };
+
+        Command::SubmitTypedCommand(
+            Command::CommandId::CmdIdCheatManagerExecute,
+            lpParams
+        );
+    }
+
+    static void HandleRevive(void) {
+        CheatManager::CheatManagerParams* lpParams = new CheatManager::CheatManagerParams{
+            .FunctionId = CheatManager::CheatManagerFunctionId::Revive,
+            .FunctionParams = {
+                reinterpret_cast<uint64_t>(
+                    UnrealUtils::GetSurvivalPlayerCharacterById()
+                ),
+                0, 0, 0
+            }
+        };
+        Command::SubmitTypedCommand(
+            Command::CommandId::CmdIdCheatManagerExecute,
+            lpParams
+        );
+    }
+
+    static void HandleAddWhiteMolars(void) {
+        int32_t iMolarAddCount = ReadIntegerInput(
+            "[AddWhiteMolars] Enter number of white molars to add: ",
+            -1
+        );
+
+        if (iMolarAddCount < 0) {
+            LogError(
+                "AddWhiteMolars",
+                "Invalid molar count, must be non-negative"
+            );
+            return;
+        }
+
+        // multi-cheatmanager future tests
+        /*int32_t iTargetPlayerId = ReadIntegerInput(
+            "[AddWhiteMolars] Enter target player ID (empty for local): ",
+            UnrealUtils::GetLocalPlayerId(true)
+        );*/
+
+        CheatManager::CheatManagerParams* lpParams = new CheatManager::CheatManagerParams{
+            .FunctionId = CheatManager::CheatManagerFunctionId::AddWhiteMolars,
+            .FunctionParams = {
+                reinterpret_cast<uint64_t>(
+                    CheatManager::GetPlayersCheatManager(UnrealUtils::GetLocalPlayerId(true))
+                ),
+                static_cast<uint64_t>(iMolarAddCount),
+                0, 0
+            }
+        };
+
+        Command::SubmitTypedCommand(
+            Command::CommandId::CmdIdCheatManagerExecute,
+            lpParams
+        );
+    }
+
+    static void HandleAddGoldMolars(void) {
+        int32_t iMolarAddCount = ReadIntegerInput(
+            "[AddGoldMolars] Enter number of gold molars to add: ",
+            -1
+        );
+        if (iMolarAddCount < 0) {
+            LogError(
+                "AddGoldMolars",
+                "Invalid molar count, must be non-negative"
+            );
+            return;
+        }
+        CheatManager::CheatManagerParams* lpParams = new CheatManager::CheatManagerParams{
+            .FunctionId = CheatManager::CheatManagerFunctionId::AddGoldMolars,
+            .FunctionParams = {
+                reinterpret_cast<uint64_t>(
+                    CheatManager::GetPlayersCheatManager(UnrealUtils::GetLocalPlayerId(true))
+                ),
+                static_cast<uint64_t>(iMolarAddCount),
+                0, 0
+            }
+        };
+        Command::SubmitTypedCommand(
+            Command::CommandId::CmdIdCheatManagerExecute,
+            lpParams
+        );
+    }
+
+    static void HandleAddBuggyUpgradePoints(void) {
+        int32_t iBuggyUpgradePoints = ReadIntegerInput(
+            "[AddBuggyUpgradePoints] Enter number of buggy upgrade points to add: ",
+            -1
+        );
+        if (iBuggyUpgradePoints < 0) {
+            LogError(
+                "AddBuggyUpgradePoints",
+                "Invalid upgrade point count, must be non-negative"
+            );
+            return;
+        }
+        CheatManager::CheatManagerParams* lpParams = new CheatManager::CheatManagerParams{
+            .FunctionId = CheatManager::CheatManagerFunctionId::AddBuggyUpgradePoints,
+            .FunctionParams = {
+                reinterpret_cast<uint64_t>(
+                    CheatManager::GetPlayersCheatManager(UnrealUtils::GetLocalPlayerId(true))
+                ),
+                static_cast<uint64_t>(iBuggyUpgradePoints),
+                0, 0
+            }
+        };
+        Command::SubmitTypedCommand(
+            Command::CommandId::CmdIdCheatManagerExecute,
+            lpParams
+        );
+    }
+
 
     void PrintAvailableCommands(void);
 
@@ -1328,7 +1511,8 @@ namespace Interpreter {
                     std::string(" - Infinite Stamina        - ") + (g_GameOptions.InfiniteStamina.load() ? "enabled" : "disabled") + "\n" + 
                     std::string(" - Pet Invincibility       - ") + (g_GameOptions.GameStatics.InvinciblePets.load() ? "enabled" : "disabled") + "\n" +
                     std::string(" - Free Crafting           - ") + (g_GameOptions.GameStatics.FreeCrafting.load() ? "enabled" : "disabled") + "\n" +
-                    std::string(" - Damage Multiplier       - ") + std::to_string(g_GameOptions.GameStatics.PlayerDamageMultiplier.load()) + "\n"
+                    std::string(" - Damage Multiplier       - ") + std::to_string(g_GameOptions.GameStatics.PlayerDamageMultiplier.load()) + "\n" +
+                    std::string(" - Infinite Damage         - ") + (g_GameOptions.InfiniteDamage.load() ? "enabled" : "disabled") + "\n"
                 );
             }
         },
@@ -1439,7 +1623,18 @@ namespace Interpreter {
         { "OPT_SetStaminaRegenDelay", "Set player stamina regen delay", []() {
             HandleStaminaRegenDelay(CheatManager::StaticCheats::EStaticCheatOp::Set);
         }},
+        { "OPT_GetBreathAdjustRate", "Get breath adjustment rate", []() {
+            HandleBreathAdjustRate(CheatManager::StaticCheats::EStaticCheatOp::Get);
+        }},
+        { "OPT_SetBreathAdjustRate", "Set breath adjustment rate", []() {
+            HandleBreathAdjustRate(CheatManager::StaticCheats::EStaticCheatOp::Set);
+        }},
         { "OPT_SetOmniToolLevel", "Set OmniTool level", HandleSetOmniToolLevel },
+        { "OPT_ToggleInfiniteDamage", "Toggle infinite damage", HandleToggleInfiniteDamage },
+        { "OPT_AddWhiteMolars", "Add white molars (PersonalUpgradePoints)", HandleAddWhiteMolars },
+        { "OPT_AddGoldMolars", "Add gold molars (PartyUpgradePoints)", HandleAddGoldMolars },
+        { "OPT_AddBuggyUpgradePoints", "Add moldy molars (BuggyUpgradePoints)", HandleAddBuggyUpgradePoints },
+        { "OPT_InvokeRevive", "Revive player character", HandleRevive }
     };
 
     void PrintAvailableCommands(

--- a/Grounded2Minimal/dllmain.cpp
+++ b/Grounded2Minimal/dllmain.cpp
@@ -104,6 +104,58 @@ void ProcessDebugFilter(
     }
 }
 
+static bool CheckGameCompat(void) {
+    constexpr uintptr_t GameVersionStringOffset = 0x8188224;
+
+    HMODULE hBaseAddress = GetModuleHandleW(nullptr);
+    if (nullptr == hBaseAddress) {
+        LogError(
+            "CheckGameCompat",
+            "Failed to get base address of the game module"
+        );
+        return false;
+    }
+
+    MEMORY_BASIC_INFORMATION mbInfo{};
+
+    if (0 == VirtualQuery(
+        hBaseAddress,
+        &mbInfo,
+        sizeof(mbInfo)
+    )) {
+        LogError(
+            "CheckGameCompat",
+            "Failed to query memory information for the game module"
+        );
+        return false;
+    }
+    
+    if (
+        mbInfo.State != MEM_COMMIT || mbInfo.Protect == PAGE_NOACCESS
+    ) {
+        LogError(
+            "CheckGameCompat",
+            "Game module memory is not committed or is inaccessible"
+        );
+        return false;
+    }
+
+    CONST BYTE abGameVersion[] = { 0x30, 0x00, 0x2E, 0x00, 0x35, 0x00, 0x2E, 0x00, 0x30, 0x00, 0x2E, 0x00, 0x33 };
+    if (0 != memcmp(
+        reinterpret_cast<const void*>(reinterpret_cast<uintptr_t>(hBaseAddress) + GameVersionStringOffset),
+        abGameVersion,
+        sizeof(abGameVersion)
+    )) {
+        LogError(
+            "CheckGameCompat",
+            "Game version string does not match expected value, the game may have been updated and is incompatible with this mod"
+        );
+        return false;
+    }
+
+    return true;
+}
+
 void ProcessDebugFilter(
     HookManager::NativeHooker::HookEntry* lpHookData,
     NativeProcessEventParams* lpParams
@@ -717,6 +769,25 @@ DWORD WINAPI ThreadEntry(
         true
     );
 
+    LogMessage(
+        "Init",
+        "Checking game version compatibility..."
+    );
+    if (!CheckGameCompat()) {
+        LogError(
+            "Init",
+            "FATAL ERROR\n"
+            "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+            "! Incompatible game version detected!     !\n"
+            "! Check for Grounded2Minimal updates.     !\n"
+            "!                                         !\n"
+            "! Press ENTER to continue...              !\n"
+            "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        );
+        iRet = EXIT_FAILURE;
+        goto _CLEAN_EXIT;
+    }
+
     while (nullptr == UnrealUtils::GetLocalPawn()) {
         LogMessage("Init", "Waiting for LocalPawn to be available...");
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
@@ -926,6 +997,7 @@ _RYUJI:
     HookManager::NativeHooker::RestoreAll();
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
+_CLEAN_EXIT:
     if (EXIT_SUCCESS != iRet) {
         LogError("Exit", "GroundedMinimal2: Exiting due to errors");
         system("pause");


### PR DESCRIPTION
## \* AUTOGENERATED \*

**New Cheat Features and Commands:**

* Added support for toggling infinite damage, reviving the player, advancing time by hours, and adding buggy upgrade points through new `CheatManagerFunctionId` values and handlers in both `CheatManager` and `Interpreter`. 
* Introduced commands to get and set the player's breath adjustment rate, including corresponding handler logic and UI prompts. 
* Added command handlers for adding white/gold molars and buggy upgrade points, providing user input validation and feedback.

**State Tracking and Game Options:**

* Added new atomic fields to `GameOptions` for `InfiniteDamage` and `BreathAdjustRate`, ensuring thread-safe tracking and access to these cheat states.
* Updated the player damage multiplier setter to also update the atomic field for consistency.

**Game Compatibility and Initialization:**

* Implemented a `CheckGameCompat()` function to verify the loaded game version matches the expected version, aborting initialization with an error if not compatible. 
* Updated version information in resource files to reflect the new release. 

**Utility and Internal Improvements:**

* Improved the status output to display the state of infinite damage and other new options.

**Bug Fixes and Minor Cleanups:**

* Removed redundant manual update of the player damage multiplier in `Interpreter` since it's now handled in `CheatManager`.
* Added a clean exit label to ensure proper cleanup on initialization failure.