### PR TITLE
Fix for v0.5.0.5

### DIFF
--- a/Grounded2Minimal/CoreUtils.cpp
+++ b/Grounded2Minimal/CoreUtils.cpp
@@ -270,7 +270,9 @@ namespace CoreUtils {
 
     DWORD32 GetSectionRVAOffset(
         LPCBYTE lpBaseAddress,
-        LPCSTR szSectionName
+        LPCSTR szSectionName,
+        LPCBYTE *lppSectionStart,
+        SIZE_T *lpcbSectionSize
     ) {
         PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER) lpBaseAddress;
         if (IMAGE_DOS_SIGNATURE != pDosHeader->e_magic) {
@@ -316,6 +318,13 @@ namespace CoreUtils {
                 '\0' != pSectionHeaders[i].Name[cbSectionName]
             ) {
                 continue;
+            }
+
+            if (nullptr != lppSectionStart) {
+                *lppSectionStart = lpBaseAddress + pSectionHeaders[i].VirtualAddress;
+            }
+            if (nullptr != lpcbSectionSize) {
+                *lpcbSectionSize = static_cast<SIZE_T>(pSectionHeaders[i].Misc.VirtualSize);
             }
 
             return pSectionHeaders[i].VirtualAddress - pSectionHeaders[i].PointerToRawData;

--- a/Grounded2Minimal/CoreUtils.hpp
+++ b/Grounded2Minimal/CoreUtils.hpp
@@ -59,7 +59,9 @@ namespace CoreUtils {
 
     DWORD32 GetSectionRVAOffset(
         LPCBYTE lpBaseAddress,
-        LPCSTR szSectionName
+        LPCSTR szSectionName,
+        LPCBYTE *lppSectionStart = nullptr,
+        SIZE_T *lpcbSectionSize = nullptr
     );
 } // namespace CoreUtils
 

--- a/Grounded2Minimal/dllmain.cpp
+++ b/Grounded2Minimal/dllmain.cpp
@@ -105,12 +105,6 @@ void ProcessDebugFilter(
 }
 
 static bool CheckGameCompat(void) {
-#if (TARGET_PLATFORM == TARGET_PLATFORM_STEAM)
-    constexpr uintptr_t GameVersionStringOffset = 0x08188224;
-#elif (TARGET_PLATFORM == TARGET_PLATFORM_XGP)
-    constexpr uintptr_t GameVersionStringOffset = 0x07A41E24;
-#endif
-
     HMODULE hBaseAddress = GetModuleHandleW(nullptr);
     if (nullptr == hBaseAddress) {
         LogError(
@@ -120,17 +114,28 @@ static bool CheckGameCompat(void) {
         return false;
     }
 
-    MEMORY_BASIC_INFORMATION mbInfo{};
+    LPCBYTE lpSectionStart = nullptr;
+    SIZE_T cbSectionSize = 0;
 
-    DWORD32 dwRdataRVA = CoreUtils::GetSectionRVAOffset(
-        reinterpret_cast<LPCBYTE>(hBaseAddress), 
-        ".rdata"
+    CoreUtils::GetSectionRVAOffset(
+        reinterpret_cast<LPCBYTE>(hBaseAddress),
+        ".rdata",
+        &lpSectionStart,
+        &cbSectionSize
     );
 
-    LPCBYTE lpcTargetVersionAddress = reinterpret_cast<LPCBYTE>(hBaseAddress) + dwRdataRVA + GameVersionStringOffset;
+    if (nullptr == lpSectionStart || 0 == cbSectionSize) {
+        LogError(
+            "CheckGameCompat",
+            "Failed to locate .rdata section in the game module"
+        );
+        return false;
+    }
+
+    MEMORY_BASIC_INFORMATION mbInfo{};
 
     if (0 == VirtualQuery(
-        lpcTargetVersionAddress,
+        lpSectionStart,
         &mbInfo,
         sizeof(mbInfo)
     )) {
@@ -151,30 +156,42 @@ static bool CheckGameCompat(void) {
         return false;
     }
 
+    // UTF-16LE encoding of "release-0.5.0.5" - the "release-" prefix makes
+    // this specific enough to avoid coincidentally matching unrelated data
+    // elsewhere in .rdata, without pinning unrelated engine/codename details
+    // (e.g. the "5.6.1-3100008+++Augusta+" prefix) that aren't part of the
+    // game's own version numbering.
     CONST BYTE abGameVersion[] = { 
+        0x72, 0x00,         // 'r'
+        0x65, 0x00,         // 'e'
+        0x6C, 0x00,         // 'l'
+        0x65, 0x00,         // 'e'
+        0x61, 0x00,         // 'a'
+        0x73, 0x00,         // 's'
+        0x65, 0x00,         // 'e'
+        0x2D, 0x00,         // '-'
         0x30, 0x00,         // '0'
         0x2E, 0x00,         // '.'
         0x35, 0x00,         // '5'
         0x2E, 0x00,         // '.'
         0x30, 0x00,         // '0'
         0x2E, 0x00,         // '.' 
-        0x34, 0x00          // '4'
+        0x35, 0x00          // '5'
     };
 
-    if (0 != memcmp(
-        reinterpret_cast<const void*>(lpcTargetVersionAddress),
-        abGameVersion,
-        sizeof(abGameVersion)
-    )) {
-        LogMessage(
-            "CheckGameCompat",
-            "Incompatibility report:\n"
-            " * BaseAddress: " + CoreUtils::HexConvert(reinterpret_cast<uintptr_t>(hBaseAddress)) + "\n"
-            " * TargetVersionAddress: " + CoreUtils::HexConvert(reinterpret_cast<uintptr_t>(lpcTargetVersionAddress)) + "\n"
-            " * .rdata RVA: " + CoreUtils::HexConvert(dwRdataRVA) + "\n",
-            true
-        );
+    constexpr SIZE_T cbNeedle = sizeof(abGameVersion);
+    bool bFound = false;
 
+    if (cbSectionSize >= cbNeedle) {
+        for (SIZE_T i = 0; i <= cbSectionSize - cbNeedle; ++i) {
+            if (0 == memcmp(lpSectionStart + i, abGameVersion, cbNeedle)) {
+                bFound = true;
+                break;
+            }
+        }
+    }
+
+    if (!bFound) {
         LogError(
             "CheckGameCompat",
             "Game version string does not match expected value, the game may have been updated and is incompatible with this mod"


### PR DESCRIPTION
1. Why extend GetSectionRVAOffset() instead of writing new code?

- The original dllmain.cpp needed to find .rdata, a section of the game's exe. CoreUtils.cpp already had a function that opens up the exe's internal PE headers (this is the file format spec every Windows .exe/.dll follows) and walks through its list of sections to find one by name. I didn't know that when I first wrote the fix, so I wrote a second copy of that same header-walking logic directly inside dllmain.cpp.

- The fix: the existing function returns one number (a distance/offset), but I also need the section's starting address and size to scan across it. So instead of writing new code to get those, I gave the existing function two optional extra output slots, pointers you can pass in to also get the address and size back, or leave as default and get the old behavior unchanged. Same single walk through the headers, just handing back more of what it already found along the way.

- The why: The information I needed was already being computed inside GetSectionRVAOffset(), it just wasn't being returned. Rather than parse the PE headers a second time, I extended the function to optionally return what it already has.

2. Why "release-0.5.0.5" instead of just "0.5.0.5"?

- The check works by literally searching the game's memory for a specific sequence of bytes. "0.5.0.5" as UTF-16 is just 14 bytes of digits and dots. There's nothing distinctive about it, that same 14-byte pattern could theoretically show up by coincidence somewhere completely unrelated in .rdata (padding, an unrelated data structure, anything), and the check would falsely report "compatible" when it isn't.

- The fix: Adding "release-" in front makes the search string 30 bytes with real letters mixed in. The odds of that exact sequence occurring by accident are effectively zero. I didn't go further and include the full string Dumper-7 originally showed ("5.6.1-3100008+++Augusta+release-0.5.0.5") because the extra prefix (engine build number, codename) isn't actually part of the game's version, tying the check to that too would mean it breaks even on updates that don't actually change anything the mod depends on.

- The why: Bare version digits aren't a unique-enough signature and risk a false positive. 'release-' is the game's own convention preceding its version number, so it scopes the check tightly to just that without over-constraining it to unrelated build metadata."

4. Why the check still fails safe?

- This one's less "what changed" and more "what didn't." The original design's whole point was: if the expected bytes aren't found, refuse to run rather than risk crashing against a genuinely incompatible game. That behavior is fully preserved, bFound starts false and it only flips to true on an exact match; anything else (nothing found, section missing, memory not accessible) still returns false and the mod exits cleanly. Nothing about the safety philosophy changed, only how the correct address/needle gets found.

- The why: The scan replaces a stale, hardcoded address with a live lookup, but the fail-closed behavior will refuse to run unless it finds an exact specific match, this is unchanged from the original design.

5. Testing.
I have tested this fix extensively for the Steam version of Grounded 2. I have not been able to fix the Xbox Game Pass version as I do not own that one.

6. Final Note.
I apologise for not going through proper procedure to submit this fix. I believe I have submitted it correctly, though I am unsure as this is the first fix I've pushed before on github. I did use "Claude" AI to help me with this as I am still a beginner when it comes to C++ code. I have written programs before in Python Script though.